### PR TITLE
Check constructor is defined when constructor set null

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function funcName (f) {
 
 function ctorName (obj) {
     var strName = toStr.call(obj).slice(8, -1);
-    if (strName === 'Object') {
+    if (strName === 'Object' && obj.constructor) {
         return funcName(obj.constructor);
     }
     return strName;

--- a/test/test_without_constructor.js
+++ b/test/test_without_constructor.js
@@ -1,0 +1,26 @@
+var NonConstructorPerson = {
+  constructor: null,
+};
+var typeName = require('..'),
+    assert = require('assert'),
+    fixtures = {
+      "Object object": NonConstructorPerson,
+    };
+
+describe('typeName of', function () {
+    var i, tests = [
+        ['Object object', 'Object'],
+    ];
+
+    for(i = 0; i < tests.length; i += 1) {
+        (function(idx){
+            var sut = tests[idx][0],
+                expected = tests[idx][1],
+                input = fixtures[sut];
+            it(sut + ' is ' + expected, function () {
+                assert.equal(typeName(input), expected);
+            });
+        })(i);
+    }
+});
+


### PR DESCRIPTION
When constructor is null, type-name throws exception like `TypeError: Cannot read property 'name' of null`.

```
TypeError: Cannot read property 'name' of null
      at funcName (/Users/furukawa.yosuke/Program/type-name/index.js:15:13)
      at ctorName (/Users/furukawa.yosuke/Program/type-name/index.js:21:16)
      at typeName (/Users/furukawa.yosuke/Program/type-name/index.js:33:16)
```

traceur-compiler sets null constructor in some classes...
