### PR TITLE
Fix crash when called with an es6 anonymous class instance

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,7 +30,7 @@
   "boss": false,
   "debug": false,
   "eqnull": false,
-  "esnext": false,
+  "esnext": true,
   "evil": false,
   "expr": false,
   "funcscope": false,

--- a/index.js
+++ b/index.js
@@ -12,7 +12,12 @@
 var toStr = Object.prototype.toString;
 
 function funcName (f) {
-    return f.name ? f.name : /^\s*function\s*([^\(]*)/im.exec(f.toString())[1];
+    if (f.name) {
+        return f.name;
+    } else {
+        var match = /^\s*function\s*([^\(]*)/im.exec(f.toString());
+        return match ? match[1] : '';
+    }
 }
 
 function ctorName (obj) {

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,8 @@ var typeName = require('..'),
         'RangeError object': new RangeError('range error!'),
         'user-defined constructor': new Person('alice', 5),
         'anonymous constructor': new AnonPerson('bob', 4),
+        'anonymous class': new(class { constructor() {} }),
+        'named class': new(class Foo { constructor() {} }),
         'NaN': NaN,
         'Infinity': Infinity,
         'Math': Math,
@@ -90,6 +92,8 @@ describe('typeName of', function () {
         ['Math',                     'Math'],
         ['user-defined constructor', 'Person'],
         ['anonymous constructor',    ''],
+        ['anonymous class',          ''],
+        ['named class',              'Foo'],
         ['null literal',             'null'],
         ['undefined value',          'undefined']
     ];


### PR DESCRIPTION
Hi,

Not sure how you would like to best handle compatibility with older node versions, >=4 is compatible with `use strict`, however older versions would need Babel (https://kangax.github.io/compat-table/es6/).

Of course this is only compatibility for that test case, perhaps it could be disabled for those node versions and the incompatible browsers.

Thanks,
Andrew