### PR TITLE
Add options to customize the default name and constructor name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ DESCRIPTION
 | arguments object *(IE9+)*  | `(function(){ return arguments; })()` | `'Arguments'` |
 | User-defined constructor | `new Person('alice', 5)` | `'Person'` |
 | Anonymous constructor | `new AnonPerson('bob', 4)` | `''` |
-| Named class | `new(class Foo { constructor() {} })` | `'Foo'` |
-| Anonymous class | `new(class { constructor() {} })` | `''` |
-| Symbol | `Symbol("FOO")` | `'symbol'` |
+| Named class | `new(class Foo { })` | `'Foo'` |
+| Anonymous class | `new(class { })` | `''` |
+| Symbol | `Symbol('FOO')` | `'symbol'` |
 | Promise | `Promise.resolve(1)` | `'Promise'` |
 
 
@@ -81,7 +81,7 @@ assert(typeName(Infinity) === 'number');
 assert(typeName(Math) === 'Math');
 assert(typeName(JSON) === 'JSON'); // IE8+
 assert(typeName((function(){ return arguments; })()) === 'Arguments');  // IE9+
-assert(typeName(Symbol("FOO")) === 'symbol');
+assert(typeName(Symbol('FOO')) === 'symbol');
 assert(typeName(Promise.resolve(1)) === 'Promise');
 
 function Person(name, age) {
@@ -89,16 +89,30 @@ function Person(name, age) {
     this.age = age;
 }
 
-var AnonPerson = function(name, age) {
+class MockPerson extends Person {}
+
+var person = new Person('alice', 5);
+var mockPerson = new MockPerson('alice', 5);
+
+var anonPerson = new function(name, age) {
     this.name = name;
     this.age = age;
 };
 
-assert(typeName(new Person('alice', 5)) === 'Person');
-assert(typeName(new AnonPerson('bob', 4)) === '');
+var getDefault = ({ constructor: ctor }) => {
+    return ctor === anonPerson.constructor ? 'AnonPerson' : '';
+};
 
-assert(typeName(new(class Foo { constructor() {} })) === 'Foo');
-assert(typeName(new(class { constructor() {} })) === '');
+var getName = ({ constructor: ctor }) => {
+    return ctor === MockPerson ? 'Person' : ctor.name;
+};
+
+assert(typeName(person) === 'Person');
+assert(typeName(anonPerson) === '');
+assert(typeName(anonPerson, { default: 'unknown' }) === 'unknown');
+assert(typeName(anonPerson, { default: getDefault }) === 'AnonPerson');
+assert(typeName(mockPerson) === 'MockPerson');
+assert(typeName(mockPerson, { name: getName }) === 'Person');
 ```
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+declare type Options = {
+    default?: string | ((value: object) => string);
+    name?: (value: object) => string;
+};
+
+declare function typeName (value: any, options?: Options): string;
+export = typeName;

--- a/index.js
+++ b/index.js
@@ -9,34 +9,42 @@
  */
 'use strict';
 
-var toStr = Object.prototype.toString;
+var toStr = {}.toString;
 
-function funcName (f) {
-    if (f.name) {
-        return f.name;
-    }
-    var match = /^\s*function\s*([^\(]*)/im.exec(f.toString());
+function extractName (obj) {
+    var match = /^\s*function\s*([^\(\s]+)/i.exec(obj.constructor.toString());
     return match ? match[1] : '';
 }
 
-function ctorName (obj) {
-    var strName = toStr.call(obj).slice(8, -1);
-    if ((strName === 'Object' || strName === 'Error') && obj.constructor) {
-        return funcName(obj.constructor);
+function ctorName (obj, options) {
+    var $default, getName = options.name;
+    var name = typeof getName === 'function' ?
+        getName(obj) :
+        obj.constructor.name;
+    if (name) {
+        return name;
+    } else {
+        $default = options['default'] || extractName;
+        return typeof $default === 'function' ? $default(obj) : $default;
     }
-    return strName;
 }
 
-function typeName (val) {
-    var type;
-    if (val === null) {
-        return 'null';
+function objectName (obj, options) {
+    var name = toStr.call(obj).slice(8, -1);
+    if ((name === 'Object' || name === 'Error') && obj.constructor) {
+        return ctorName(obj, options);
+    } else {
+        return name;
     }
-    type = typeof val;
+}
+
+function typeName (val, options) {
+    var type = val === null ? 'null' : typeof val;
     if (type === 'object') {
-        return ctorName(val);
+        return objectName(val, options || {});
+    } else {
+        return type;
     }
-    return type;
 }
 
 module.exports = typeName;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "build/type-name.js"
   ],
   "homepage": "https://github.com/twada/type-name",
@@ -50,6 +51,7 @@
   ],
   "license": "MIT",
   "main": "./index.js",
+  "types": "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/twada/type-name.git"

--- a/test/options.es6
+++ b/test/options.es6
@@ -1,0 +1,73 @@
+'use strict';
+
+const assert = require('assert');
+const typeName = require('..');
+
+const getDefault = name => value => {
+    assert(value);
+    assert(value.constructor);
+    assert(!value.constructor.name);
+    return name;
+};
+
+const getName = name => value => {
+    assert(value);
+    assert(value.constructor);
+    return name;
+};
+
+describe('options (ES6)', () => {
+    it('default (string, anonymous class)', () => {
+        const input = new class { };
+        assert.equal(typeName(input), '');
+        assert.equal(typeName(input, { 'default': '' }), '');
+        assert.equal(typeName(input, { 'default': 'unknown' }), 'unknown');
+        assert.equal(typeName(input, { 'default': 'Foo' }), 'Foo');
+    });
+
+    it('default (string, named class)', () => {
+        const input = new class Foo { };
+        assert.equal(typeName(input), 'Foo');
+        assert.equal(typeName(input, { 'default': '' }), 'Foo');
+        assert.equal(typeName(input, { 'default': 'unknown' }), 'Foo');
+        assert.equal(typeName(input, { 'default': 'Bar' }), 'Foo');
+    });
+
+    it('default (function, anonymous class)', () => {
+        const input = new class { };
+        assert.equal(typeName(input), '');
+        assert.equal(typeName(input, { 'default': getDefault('unknown') }), 'unknown');
+        assert.equal(typeName(input, { 'default': getDefault('Foo') }), 'Foo');
+    });
+
+    it('default (function, named class)', () => {
+        const input = new class Foo { };
+        assert.equal(typeName(input), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('') }), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('unknown') }), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('Foo') }), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('Bar') }), 'Foo');
+    });
+
+    it('name (anonymous class)', () => {
+        const input = new class { };
+        assert.equal(typeName(input), '');
+        assert.equal(typeName(input, { name: 'Invalid' }), '');
+        assert.equal(typeName(input, { name: ['Invalid'] }), '');
+        assert.equal(typeName(input, { name: getName('Bar') }), 'Bar');
+        assert.equal(typeName(input, { 'default': 'Baz', name: getName('Bar') }), 'Bar');
+        assert.equal(typeName(input, { 'default': 'Baz', name: getName('') }), 'Baz');
+    });
+
+    it('name (named class)', () => {
+        const input = new class Foo { };
+        assert.equal(typeName(input), 'Foo');
+        assert.equal(typeName(input, { name: 'Invalid' }), 'Foo');
+        assert.equal(typeName(input, { name: ['Invalid'] }), 'Foo');
+        assert.equal(typeName(input, { name: getName('Bar') }), 'Bar');
+        assert.equal(typeName(input, { 'default': 'Bar', name: getName('') }), 'Bar');
+        // XXX the scraper doesn't parse "class Foo {}"
+        assert.equal(typeName(input, { name: getName('') }), '');
+    });
+
+});

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var assert = require('assert');
+var typeName = require('..');
+
+function getDefault (name) {
+    return function (value) {
+        assert(value);
+        assert(value.constructor);
+        assert(!value.constructor.name);
+        return name;
+    };
+}
+
+function getName (name) {
+    return function (value) {
+        assert(value);
+        assert(value.constructor);
+        return name;
+    };
+}
+
+describe('options', function ()  {
+    it('default (string, anonymous class)', function () {
+        var input = new function () { };
+        assert.equal(typeName(input), '');
+        assert.equal(typeName(input, { 'default': '' }), '');
+        assert.equal(typeName(input, { 'default': 'unknown' }), 'unknown');
+        assert.equal(typeName(input, { 'default': 'Foo' }), 'Foo');
+    });
+
+    it('default (string, named class)', function () {
+        var input = new function Foo () { };
+        assert.equal(typeName(input), 'Foo');
+        assert.equal(typeName(input, { 'default': '' }), 'Foo');
+        assert.equal(typeName(input, { 'default': 'unknown' }), 'Foo');
+        assert.equal(typeName(input, { 'default': 'Bar' }), 'Foo');
+    });
+
+    it('default (function, anonymous class)', function ()  {
+        var input = new function () { };
+        assert.equal(typeName(input), '');
+        assert.equal(typeName(input, { 'default': getDefault('unknown') }), 'unknown');
+        assert.equal(typeName(input, { 'default': getDefault('Foo') }), 'Foo');
+    });
+
+    it('default (function, named class)', function ()  {
+        var input = new function Foo () { };
+        assert.equal(typeName(input), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('') }), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('unknown') }), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('Foo') }), 'Foo');
+        assert.equal(typeName(input, { 'default': getDefault('Bar') }), 'Foo');
+    });
+
+    it('name (anonymous class)', function ()  {
+        var input = new function () { };
+        assert.equal(typeName(input), '');
+        assert.equal(typeName(input, { name: 'Invalid' }), '');
+        assert.equal(typeName(input, { name: ['Invalid'] }), '');
+        assert.equal(typeName(input, { name: getName('Bar') }), 'Bar');
+        assert.equal(typeName(input, { 'default': 'Baz', name: getName('Bar') }), 'Bar');
+        assert.equal(typeName(input, { 'default': 'Baz', name: getName('') }), 'Baz');
+    });
+
+    it('name (named class)', function ()  {
+        var input = new function Foo () { };
+        assert.equal(typeName(input), 'Foo');
+        assert.equal(typeName(input, { name: 'Invalid' }), 'Foo');
+        assert.equal(typeName(input, { name: ['Invalid'] }), 'Foo');
+        assert.equal(typeName(input, { name: getName('Bar') }), 'Bar');
+        assert.equal(typeName(input, { 'default': 'Bar', name: getName('') }), 'Bar');
+        assert.equal(typeName(input, { name: getName('') }), 'Foo');
+    });
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,43 +1,62 @@
+'use strict';
+
+var assert = require('assert');
+var typeName = require('..');
+var woothee = require('woothee');
+
+// use indirection to avoid name assignment under ES6
+function anon (fn) {
+    assert(!fn.name);
+    return fn;
+}
+
 function Person(name, age) {
     this.name = name;
     this.age = age;
 }
 
-var AnonPerson = function(name, age) {
+var AnonymousPerson = anon(function(name, age) {
     this.name = name;
     this.age = age;
+});
+
+var PseudonymousPerson = anon(function(name, age) {
+    this.name = name;
+    this.age = age;
+});
+
+PseudonymousPerson.toString = function () {
+    return 'function PseudonymousPerson () { }';
 };
 
-var typeName = require('..'),
-    woothee = require('woothee'),
-    assert = require('assert'),
-    fixtures = {
-        'string literal': 'foo',
-        'number literal': 5,
-        'boolean literal': false,
-        'regexp literal': /^not/,
-        'array literal': ['foo', 4],
-        'object literal': {name: 'bar'},
-        'function expression': function () {},
-        'String object': new String('foo'),
-        'Number object': new Number('3'),
-        'Boolean object':new Boolean('1'),
-        'Date object': new Date(),
-        'RegExp object': new RegExp('^not', 'g'),
-        'Array object': new Array(),
-        'Object object': new Object(),
-        'Function object': new Function('x', 'y', 'return x + y'),
-        'Error object': new Error('error!'),
-        'TypeError object': new TypeError('type error!'),
-        'RangeError object': new RangeError('range error!'),
-        'user-defined constructor': new Person('alice', 5),
-        'anonymous constructor': new AnonPerson('bob', 4),
-        'NaN': NaN,
-        'Infinity': Infinity,
-        'Math': Math,
-        'null literal': null,
-        'undefined value': undefined
-    };
+var fixtures = {
+    'string literal': 'foo',
+    'number literal': 5,
+    'boolean literal': false,
+    'regexp literal': /^not/,
+    'array literal': ['foo', 4],
+    'object literal': {name: 'bar'},
+    'function expression': function () {},
+    'String object': new String('foo'),
+    'Number object': new Number('3'),
+    'Boolean object':new Boolean('1'),
+    'Date object': new Date(),
+    'RegExp object': new RegExp('^not', 'g'),
+    'Array object': new Array(),
+    'Object object': new Object(),
+    'Function object': new Function('x', 'y', 'return x + y'),
+    'Error object': new Error('error!'),
+    'TypeError object': new TypeError('type error!'),
+    'RangeError object': new RangeError('range error!'),
+    'user-defined constructor': new Person('alice', 5),
+    'anonymous constructor': new AnonymousPerson('bob', 4),
+    'pseudonymous constructor': new PseudonymousPerson('nemo', 3),
+    'NaN': NaN,
+    'Infinity': Infinity,
+    'Math': Math,
+    'null literal': null,
+    'undefined value': undefined
+};
 
 function addJsonSuite (tests, fixtures) {
     if (typeof JSON === 'undefined') {
@@ -90,6 +109,7 @@ describe('typeName of', function () {
         ['Math',                     'Math'],
         ['user-defined constructor', 'Person'],
         ['anonymous constructor',    ''],
+        ['pseudonymous constructor', 'PseudonymousPerson'],
         ['null literal',             'null'],
         ['undefined value',          'undefined']
     ];

--- a/test/travis_es6.sh
+++ b/test/travis_es6.sh
@@ -2,5 +2,5 @@
 
 if [ "$TRAVIS_NODE_VERSION" -a "$TRAVIS_NODE_VERSION" != "0.10" -a "$TRAVIS_NODE_VERSION" != "0.12" ]
 then
-    $(npm bin)/mocha test/es6_test.es6
+    $(npm bin)/mocha test/*.es6
 fi


### PR DESCRIPTION
1\) Allow the default name for anonymous types to be supplied as a string or function.
2) Allow the constructor name to be resolved by a custom function.
3) Fix a bug in the `Function#toString` scraper which was including spaces after the function name.
4) Add TypeScript typings.

---

1\) allows the missing name to be replaced with a string, e.g.:

```javascript
const anon = new class {}

typeName(anon)                         // ""
typeName(anon, { default: 'unknown' }) // "unknown"
```

or with a function which returns a name, e.g.:

```javascript
const anon = new class {}
const getDefault = value => '<anonymous>'

typeName(anon)                          // ""
typeName(anon, { default: getDefault }) // "<anonymous>"
```

2\) allows a function to be supplied to resolve/override the constructor name, e.g.:

```javascript
const named = new class Foo {}
const getName = value => 'Bar'

typeName(named)                    // "Foo"
typeName(named, { name: getName }) // "Bar"
```

These can be used to replace missing names when the type is known, and to replace defined names when the name is wrong, e.g. when code is minified:

```javascript
const AnonArray = Array.bind()
const getDefault = ({ constructor: ctor }) => ctor === AnonArray ? 'Array' : ''
const array = new AnonArray()

typeName(array)                          // ""
typeName(array, { default: getDefault }) // "Array"
```

```javascript
const jQuery = require('./lib/jquery-3.5.1.min.js')
const $foo = jQuery('#foo')
const getName = ({ constructor: ctor }) => ctor === jQuery ? 'jQuery' : ctor.name

typeName($foo)                    // "S"
typeName($foo, { name: getName }) // "jQuery"
```

For backwards compatibility, if no default name is supplied, the regex-based extractor is used, falling back to "" if the name can't be extracted. If the name option isn't supplied, the constructor name is used.