### PR TITLE
Fix the regex-based name scraper

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function funcName (f) {
     if (f.name) {
         return f.name;
     }
-    var match = /^\s*function\s*([^\(]*)/im.exec(f.toString());
+    var match = /^\s*function\s*([^\(\s]+)/i.exec(f.toString());
     return match ? match[1] : '';
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,43 +1,60 @@
+var assert = require('assert');
+var typeName = require('..');
+var woothee = require('woothee');
+
+// use indirection to avoid name assignment in ES6
+function anon (fn) {
+    assert(!fn.name);
+    return fn;
+}
+
 function Person(name, age) {
     this.name = name;
     this.age = age;
 }
 
-var AnonPerson = function(name, age) {
+var AnonymousPerson = anon(function(name, age) {
     this.name = name;
     this.age = age;
+});
+
+var PseudonymousPerson = anon(function(name, age) {
+    this.name = name;
+    this.age = age;
+});
+
+PseudonymousPerson.toString = function () {
+    return 'function PseudonymousPerson () { }';
 };
 
-var typeName = require('..'),
-    woothee = require('woothee'),
-    assert = require('assert'),
-    fixtures = {
-        'string literal': 'foo',
-        'number literal': 5,
-        'boolean literal': false,
-        'regexp literal': /^not/,
-        'array literal': ['foo', 4],
-        'object literal': {name: 'bar'},
-        'function expression': function () {},
-        'String object': new String('foo'),
-        'Number object': new Number('3'),
-        'Boolean object':new Boolean('1'),
-        'Date object': new Date(),
-        'RegExp object': new RegExp('^not', 'g'),
-        'Array object': new Array(),
-        'Object object': new Object(),
-        'Function object': new Function('x', 'y', 'return x + y'),
-        'Error object': new Error('error!'),
-        'TypeError object': new TypeError('type error!'),
-        'RangeError object': new RangeError('range error!'),
-        'user-defined constructor': new Person('alice', 5),
-        'anonymous constructor': new AnonPerson('bob', 4),
-        'NaN': NaN,
-        'Infinity': Infinity,
-        'Math': Math,
-        'null literal': null,
-        'undefined value': undefined
-    };
+var fixtures = {
+    'string literal': 'foo',
+    'number literal': 5,
+    'boolean literal': false,
+    'regexp literal': /^not/,
+    'array literal': ['foo', 4],
+    'object literal': {name: 'bar'},
+    'function expression': function () {},
+    'String object': new String('foo'),
+    'Number object': new Number('3'),
+    'Boolean object':new Boolean('1'),
+    'Date object': new Date(),
+    'RegExp object': new RegExp('^not', 'g'),
+    'Array object': new Array(),
+    'Object object': new Object(),
+    'Function object': new Function('x', 'y', 'return x + y'),
+    'Error object': new Error('error!'),
+    'TypeError object': new TypeError('type error!'),
+    'RangeError object': new RangeError('range error!'),
+    'user-defined constructor': new Person('alice', 5),
+    'anonymous constructor': new AnonymousPerson('bob', 4),
+    'pseudonymous constructor': new PseudonymousPerson('nemo', 3),
+    'NaN': NaN,
+    'Infinity': Infinity,
+    'Math': Math,
+    'null literal': null,
+    'undefined value': undefined
+};
 
 function addJsonSuite (tests, fixtures) {
     if (typeof JSON === 'undefined') {
@@ -90,6 +107,7 @@ describe('typeName of', function () {
         ['Math',                     'Math'],
         ['user-defined constructor', 'Person'],
         ['anonymous constructor',    ''],
+        ['pseudonymous constructor', 'PseudonymousPerson'],
         ['null literal',             'null'],
         ['undefined value',          'undefined']
     ];


### PR DESCRIPTION
Remove the trailing space after the name extracted from `Function#toString`.

I think the regex-based name scraper should be removed as it's seldom-used, fragile, increases the bundle size, and doesn't work with minified code (although neither does [`constructor.name`](https://github.com/twada/type-name/pull/12)), but as long as it's used it should work as expected.

### Setup

```javascript
// avoid name assignment in ES6
var anon = function (fn) { return fn }

var Person = anon(function (name, age) {
    this.name = name
    this.age = age
})

Person.toString = function () {
    return 'function Person () { }'
}

var person = new Person('Alice', 42)
```

### Before

```javascript
typeName(person) // "Person "
```

### After

```javascript
typeName(person) // "Person"
```